### PR TITLE
Fix version ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@ bin/
 .classpath
 .project
 
+# LSP
+workspace/
+
 # macOS
 *.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ bin/
 .classpath
 .project
 
-# LSP
+# Eclipse JDT LS
 workspace/
 
 # macOS

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs = -Xmx1G
 org.gradle.parallel = true
 
 # Mod Properties
-version = 1.0.0+1.18.2
+version = 1.0.0+1.19
 maven_group = com.example
 archives_base_name = example_mod
 


### PR DESCRIPTION
Due to the 1.19 update, the version ID listed in `gradle.properties` became out of date. This PR fixes it and tells the gitignore to drop files made by the Eclipse JDT language server.