### PR TITLE
Add .gitattributes generated by gradle init

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+#
+# https://help.github.com/articles/dealing-with-line-endings/
+#
+# Linux start script should use lf
+/gradlew        text eol=lf
+
+# These are Windows script files and should use crlf
+*.bat           text eol=crlf
+


### PR DESCRIPTION
This ensures `gradlew` and `gradlew.bat` will always have the right line endings (if this is not done, Git for Windows' autocrlf causes differences between commits created on Linux and on Windows)