### PR TITLE
Add .gitattributes: QSL Edition

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,28 @@
+*.java          text    eol=lf  diff=java
+*.gradle        text    eol=lf  diff=java
+gradlew         text    eol=lf
+*.bat           text    eol=crlf
+
+*.md            text    eol=lf  diff=markdown
+
+.editorconfig   text    eol=lf
+
+*.json          text    eol=lf
+*.json5         text    eol=lf
+*.properties    text    eol=lf
+*.toml          text    eol=lf
+*.xml           text    eol=lf  diff=html
+
+# Modding specific
+*.accesswidener text    eol=lf
+
+# These files are binary and should be left untouched
+# (binary is a macro for -text -diff)
+*.class         binary
+*.dll           binary
+*.ear           binary
+*.jar           binary
+*.jks           binary
+*.png           binary
+*.so            binary
+*.war           binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
 *.java          text    eol=lf  diff=java
 *.gradle        text    eol=lf  diff=java
+*.kt            text    eol=lf  diff=kotlin
+*.kts           text    eol=lf  diff=kotlin
 gradlew         text    eol=lf
 *.bat           text    eol=crlf
 


### PR DESCRIPTION
Succeeds #20; This fixes gradle.bat not being CRLF while making everything else LF/binary, but this time, it has a more complete .gitattributes based on Aurora's work on QSL;

I'm curious to see if there are any missing spots to cover before merging!