### PR TITLE
add a mod id constant in `ExampleMod.java`

### DIFF
--- a/src/main/java/com/example/example_mod/ExampleMod.java
+++ b/src/main/java/com/example/example_mod/ExampleMod.java
@@ -11,6 +11,9 @@ public class ExampleMod implements ModInitializer {
 	// That way, it's clear which mod wrote info, warnings, and errors.
 	public static final Logger LOGGER = LoggerFactory.getLogger("Example Mod");
 
+	// A central place to house your mod ID.
+	public static final String MOD_ID = "example_mod";
+
 	@Override
 	public void onInitialize(ModContainer mod) {
 		LOGGER.info("Hello Quilt world from {}!", mod.metadata().name());

--- a/src/main/java/com/example/example_mod/ExampleMod.java
+++ b/src/main/java/com/example/example_mod/ExampleMod.java
@@ -11,11 +11,16 @@ public class ExampleMod implements ModInitializer {
 	// That way, it's clear which mod wrote info, warnings, and errors.
 	public static final Logger LOGGER = LoggerFactory.getLogger("Example Mod");
 
-	// A central place to house your mod ID.
+	// A central place to house your mod ID. This should match the ID in your quilt.mod.json file.
 	public static final String MOD_ID = "example_mod";
 
 	@Override
 	public void onInitialize(ModContainer mod) {
+		// the following block validates that you've updated both the quilt.mod.json file and MOD_ID field when you change your mod ID. if you're familiar with making mods, feel free to remove this!
+		if (!mod.metadata().id().equals(MOD_ID)) {
+			throw new RuntimeException(String.format("Mod IDs in quilt.mod.json and MOD_ID field do not match! (quilt.mod.json: %s; MOD_ID: %s", mod.metadata().id(), MOD_ID));
+		}
+
 		LOGGER.info("Hello Quilt world from {}!", mod.metadata().name());
 	}
 }


### PR DESCRIPTION
this is pretty much needed for any mod that does anything. users who won't be doing registry or config stuff are definitely savvy enough to understand that they don't need this