### PR TITLE
Update libs.versions.toml and dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
+# The latest versions are available at https://quiltmc.org/en/usage/latest-versions/
 [versions]
-# The latest versions are available at https://lambdaurora.dev/tools/import_quilt.html
 minecraft = "1.20.4"
-loom = "1.5.7"
-
 quilt_mappings = "1.20.4+build.3"
-quilt_loader = "0.24.0"
 
-quilted_fabric_api = "9.0.0-alpha.5+0.96.11-1.20.4"
+quilt_loom = "1.6.5"
+quilt_loader = "0.25.0"
+
+quilted_fabric_api = "9.0.0-alpha.8+0.97.0-1.20.4"
 
 [libraries]
 minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }
@@ -21,4 +21,4 @@ quilted_fabric_api_deprecated = { module = "org.quiltmc.quilted-fabric-api:quilt
 quilted_fabric_api = ["quilted_fabric_api", "quilted_fabric_api_deprecated"]
 
 [plugins]
-quilt_loom = { id = "org.quiltmc.loom", version.ref = "loom" }
+quilt_loom = { id = "org.quiltmc.loom", version.ref = "quilt_loom" }


### PR DESCRIPTION
This finally erases the third-party link as well as cleans up the messy order left behind