### PR TITLE
upgrade dependencies for 1.21

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,27 +1,25 @@
 # The latest versions are available at https://quiltmc.org/en/usage/latest-versions/
 [versions]
-minecraft = "1.20.6"
-quilt_mappings = "1.20.6+build.6"
+minecraft = "1.21"
+quilt_mappings = "1.21+build.19"
 
-quilt_loom = "1.7.4"
-quilt_loader = "0.26.3"
+quilt_loom = "1.8.5"
+quilt_loader = "0.28.0-beta.8"
 
-quilted_fabric_api = "10.0.0-alpha.3+0.100.4-1.20.6"
-quilt_standard_libraries = "9.0.0-alpha.1+1.20.6"
+quilted_fabric_api = "11.0.0-alpha.3+0.102.0-1.21"
 
 [libraries]
 minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }
 quilt_mappings = { module = "org.quiltmc:quilt-mappings", version.ref = "quilt_mappings" }
 quilt_loader = { module = "org.quiltmc:quilt-loader", version.ref = "quilt_loader" }
 
-quilt_standard_libraries = { module = "org.quiltmc:qsl", version.ref = "quilt_standard_libraries" }
 quilted_fabric_api = { module = "org.quiltmc.quilted-fabric-api:quilted-fabric-api", version.ref = "quilted_fabric_api" }
 quilted_fabric_api_deprecated = { module = "org.quiltmc.quilted-fabric-api:quilted-fabric-api-deprecated", version.ref = "quilted_fabric_api" }
 
 # If you have multiple similar dependencies, you can declare a dependency bundle and reference it on the build script with "libs.bundles.example".
 [bundles]
-quilted_fabric_api = ["quilted_fabric_api", "quilt_standard_libraries"]
-quilted_fabric_api_deprecated = ["quilted_fabric_api", "quilt_standard_libraries", "quilted_fabric_api_deprecated"]
+quilted_fabric_api = ["quilted_fabric_api"]
+quilted_fabric_api_deprecated = ["quilted_fabric_api", "quilted_fabric_api_deprecated"]
 
 [plugins]
 quilt_loom = { id = "org.quiltmc.loom", version.ref = "quilt_loom" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,19 +7,21 @@ quilt_loom = "1.8.5"
 quilt_loader = "0.28.0-beta.8"
 
 quilted_fabric_api = "11.0.0-alpha.3+0.102.0-1.21"
+quilt_standard_libraries = "10.0.0-alpha.1+1.21"
 
 [libraries]
 minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }
 quilt_mappings = { module = "org.quiltmc:quilt-mappings", version.ref = "quilt_mappings" }
 quilt_loader = { module = "org.quiltmc:quilt-loader", version.ref = "quilt_loader" }
 
+quilt_standard_libraries = { module = "org.quiltmc:qsl", version.ref = "quilt_standard_libraries" }
 quilted_fabric_api = { module = "org.quiltmc.quilted-fabric-api:quilted-fabric-api", version.ref = "quilted_fabric_api" }
 quilted_fabric_api_deprecated = { module = "org.quiltmc.quilted-fabric-api:quilted-fabric-api-deprecated", version.ref = "quilted_fabric_api" }
 
 # If you have multiple similar dependencies, you can declare a dependency bundle and reference it on the build script with "libs.bundles.example".
 [bundles]
-quilted_fabric_api = ["quilted_fabric_api"]
-quilted_fabric_api_deprecated = ["quilted_fabric_api", "quilted_fabric_api_deprecated"]
+quilted_fabric_api = ["quilted_fabric_api", "quilt_standard_libraries"]
+quilted_fabric_api_deprecated = ["quilted_fabric_api", "quilt_standard_libraries", "quilted_fabric_api_deprecated"]
 
 [plugins]
 quilt_loom = { id = "org.quiltmc.loom", version.ref = "quilt_loom" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -24,15 +24,15 @@
 		"depends": [
 			{
 				"id": "quilt_loader",
-				"versions": ">=0.19.1"
+				"versions": ">=0.29.0"
 			},
 			{
 				"id": "quilted_fabric_api",
-				"versions": ">=7.0.2"
+				"versions": ">=11.0.0"
 			},
 			{
 				"id": "minecraft",
-				"versions": ">=1.20"
+				"versions": ">=1.21"
 			}
 		]
 	},


### PR DESCRIPTION
title
pushed gradle up to the oldest acceptable version (8.10) as opposed to latest because i don't want intellij yelling at me over groovy